### PR TITLE
Fix location hours query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-07-10 -- v1.0.2
+### Fixed
+- Fix location hours query to retrieve each location's current hours rather than its first hours
+
 ## 2024-05-14 -- v1.0.1
 ### Fixed
 - Do not throw an error if the ShopperTrak API rate limit is hit


### PR DESCRIPTION
The previous query mistakenly checked for when the `date_of_change` was NULL, but that actually indicates those were the hours when the LocationHours poller first started running. Instead, we need to be checking for the hours with the latest `date_of_change`.