### PR TITLE
Handle unrecognized site ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-11-14 -- v1.0.4
+### Fixed
+- When site ID is not found (error code "E101"), skip it without throwing an error
+
 ## 2024-10-10 -- v1.0.3
 ### Fixed
 - Retry when server is down (new ShopperTrak error code "E000")

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -181,9 +181,10 @@ class PipelineController:
             site_xml_root = self.shoppertrak_api_client.query(
                 SINGLE_SITE_ENDPOINT + row[0], row[1]
             )
-            # If multiple sites match the same site ID (E104), continue to the next site
-            # ID. If the API limit has been reached (E107), stop.
-            if site_xml_root == "E104":
+            # If the site ID can't be found (E101) or multiple sites match the same site
+            # ID (E104), continue to the next site. If the API limit has been reached
+            # (E107), stop.
+            if site_xml_root == "E101" or site_xml_root == "E104":
                 continue
             elif site_xml_root == "E107":
                 break

--- a/lib/shoppertrak_api_client.py
+++ b/lib/shoppertrak_api_client.py
@@ -204,8 +204,16 @@ class ShopperTrakApiClient:
             ) from None
 
         if error is not None and error.text is not None:
+            # E000 is used when ShopperTrak is down and they recommend trying again
+            if error.text == "E000":
+                self.logger.info("E000: ShopperTrak is down")
+                return "E000"
+            # E101 is used when the given site ID is not recognized
+            elif error.text == "E101":
+                self.logger.warning("E101: site ID not found")
+                return "E101"
             # E104 is used when the given site ID matches multiple sites
-            if error.text == "E104":
+            elif error.text == "E104":
                 self.logger.warning("E104: site ID has multiple matches")
                 return "E104"
             # E107 is used when the daily API limit has been exceeded
@@ -216,10 +224,6 @@ class ShopperTrakApiClient:
             elif error.text == "E108":
                 self.logger.info("E108: ShopperTrak is busy")
                 return "E108"
-            # E000 is used when ShopperTrak is down and they recommend trying again
-            elif error.text == "E000":
-                self.logger.info("E000: ShopperTrak is down")
-                return "E000"
             else:
                 self.logger.error(f"Error found in XML response: {response_text}")
                 raise ShopperTrakApiClientError(

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -323,9 +323,9 @@ class TestPipelineController:
             ]
         )
 
-    def test_recover_data_duplicate_sites(self, test_instance, mock_logger, mocker):
+    def test_recover_data_bad_sites(self, test_instance, mock_logger, mocker):
         test_instance.shoppertrak_api_client.query.side_effect = [
-            _TEST_XML_ROOT, "E104", _TEST_XML_ROOT]
+            _TEST_XML_ROOT, "E104", "E101", _TEST_XML_ROOT]
         mocked_process_recovered_data_method = mocker.patch(
             "lib.pipeline_controller.PipelineController._process_recovered_data"
         )
@@ -334,6 +334,7 @@ class TestPipelineController:
             [
                 ("aa", date(2023, 12, 1)),
                 ("bb", date(2023, 12, 1)),
+                ("cc", date(2023, 12, 1)),
                 ("aa", date(2023, 12, 2)),
             ],
             _TEST_KNOWN_DATA_DICT,


### PR DESCRIPTION
When ShopperTrak site ID is not found (error code "E101" -- this happens when a site changes names), skip it without throwing an error, allowing the rest of the sites to still be queried.