### PR TITLE
Catch all API error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-11-21 -- v1.0.5
+### Fixed
+- Catch non-fatal XML errors and continue requesting. Only throw an error and stop when the API limit has been exceeded, when the request itself has failed, or when the ShopperTrak server cannot be reached even after retrying.
+
 ## 2024-11-14 -- v1.0.4
 ### Fixed
 - When site ID is not found (error code "E101"), skip it without throwing an error

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,4 +1,5 @@
 from .shoppertrak_api_client import (
+    APIStatus,
     ShopperTrakApiClient,
     ShopperTrakApiClientError,
     ALL_SITES_ENDPOINT,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nypl-py-utils[avro-client,kinesis-client,redshift-client,s3-client,config-helper]==1.4.0
+nypl-py-utils[avro-client,kinesis-client,redshift-client,s3-client,config-helper]==1.5.0
 pytz
 requests


### PR DESCRIPTION
To avoid having to update the code for each new error code, we will catch all of them and only throw an error when the API limit has been hit or the server cannot be reached. This is because the other error codes are usually request-specific errors and should not prevent the code from continuing to send new requests with different parameters. Also added tuple unpacking for improved readability.