### PR TITLE
Parse site ID before hitting API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-12-19 -- v1.0.6
+### Fixed
+- URL quote special characters in site IDs to escape them
+
 ## 2024-11-21 -- v1.0.5
 ### Fixed
 - Catch non-fatal XML errors and continue requesting. Only throw an error and stop when the API limit has been exceeded, when the request itself has failed, or when the ShopperTrak server cannot be reached even after retrying.

--- a/lib/shoppertrak_api_client.py
+++ b/lib/shoppertrak_api_client.py
@@ -9,6 +9,7 @@ from enum import Enum
 from nypl_py_utils.functions.log_helper import create_log
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
+from urllib.parse import quote
 
 ALL_SITES_ENDPOINT = "allsites"
 SINGLE_SITE_ENDPOINT = "site/"
@@ -41,7 +42,7 @@ class ShopperTrakApiClient:
         if the query was successful, b) returns APIStatus.ERROR if the query failed but
         others should be attempted, or c) waits and tries again if the API was busy.
         """
-        full_url = self.base_url + endpoint
+        full_url = self.base_url + quote(endpoint)
         date_str = query_date.strftime("%Y%m%d")
 
         self.logger.info(f"Querying {endpoint} for {date_str} data")

--- a/tests/test_shoppertrak_api_client.py
+++ b/tests/test_shoppertrak_api_client.py
@@ -111,7 +111,7 @@ class TestPipelineController:
 
     def test_query(self, test_instance, requests_mock, mocker):
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint"
+            "https://test_shoppertrak_url/test%20-%20endpoint%3B%20one"
             "?date=20231231&increment=15&total_property=N",
             text=_TEST_API_RESPONSE,
         )
@@ -122,7 +122,7 @@ class TestPipelineController:
             return_value=(APIStatus.SUCCESS, xml_root),
         )
 
-        assert test_instance.query("test_endpoint", date(2023, 12, 31)) == xml_root
+        assert test_instance.query("test - endpoint; one", date(2023, 12, 31)) == xml_root
         mocked_check_response_method.assert_called_once_with(_TEST_API_RESPONSE)
 
     def test_query_request_exception(self, test_instance, requests_mock, mocker, caplog):


### PR DESCRIPTION
Otherwise sites like with special characters will not be recognized by the API