### PR TITLE
Send unhealthy data to Kinesis for missing sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-12-30 -- v1.1.1
+### Fixed
+- For days that are missing entire sites, send any recovered data to Kinesis even if it's unhealthy
+- For days that are missing entire sites, re-query the API even if the site is temporarily closed that day
+
 ## 2024-12-23 -- v1.1.0
 ### Added
 - Re-query ShopperTrak API for sites missing from a previous API response. This is distinct from re-querying for sites that appear in the API response but have unhealthy data (which is already done).

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -24,7 +24,7 @@ _REDSHIFT_CLOSURES_QUERY = """
     FROM {closures_table}
     LEFT JOIN {codes_table}
         ON {closures_table}.drupal_location_id = {codes_table}.drupal_code
-    WHERE closure_date >= '{start_date}' AND is_full_day;"""
+    WHERE closure_date >= '{start_date}' AND is_extended_closure AND is_full_day;"""
 
 _REDSHIFT_FOUND_SITES_QUERY = """
     SELECT shoppertrak_site_id, increment_start::DATE AS visits_date

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -307,14 +307,6 @@ class TestPipelineController:
 
     def test_process_broken_orbits_missing_sites(
             self, test_instance, mock_logger, mocker):
-        RESULT = [
-            ("aa", date(2023, 12, 1)),
-            ("bb", date(2023, 12, 1)),
-            ("cc", date(2023, 12, 1)),
-            ("ee", date(2023, 12, 1)),
-            ("aa", date(2023, 12, 2)),
-            ("dd", date(2023, 12, 2)),
-        ]
         mocked_closures_query = mocker.patch(
             "lib.pipeline_controller.build_redshift_closures_query",
             return_value="CLOSURES",
@@ -342,9 +334,13 @@ class TestPipelineController:
             "branch_codes_map_test_redshift_name",
             date(2023, 12, 1),
         )
-        mocked_recover_data_method.assert_called_once_with(
-            RESULT, _TEST_KNOWN_DATA_DICT,
-        )
+        mocked_recover_data_method.assert_has_calls([
+            mocker.call([("ee", date(2023, 12, 1)), ("dd", date(2023, 12, 2))],
+                        dict(), is_recovery_mode=False),
+            mocker.call([("aa", date(2023, 12, 1)), ("bb", date(2023, 12, 1)),
+                         ("cc", date(2023, 12, 1)), ("aa", date(2023, 12, 2))],
+                        _TEST_KNOWN_DATA_DICT),
+        ])
 
     def test_recover_data(self, test_instance, mock_logger, mocker):
         TEST_API_DATA = _build_test_api_data("2023-12-01", True)


### PR DESCRIPTION
Note for reviewer: most of the code has been moved, not changed. The key thing is that `is_recovery_mode` is set to false for the missing sites, which means unhealthy data will still be sent to Kinesis for those sites.