### PR TITLE
Don't re-query when unhealthy data is during extended closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-02-04 -- v1.1.2
+### Fixed
+- Do not attempt to recover healthy data by re-querying ShopperTrak when the initial unhealthy data occurred during an extended closure
+
 ## 2024-12-30 -- v1.1.1
 ### Fixed
 - For days that are missing entire sites, send any recovered data to Kinesis even if it's unhealthy

--- a/lib/shoppertrak_api_client.py
+++ b/lib/shoppertrak_api_client.py
@@ -167,10 +167,11 @@ class ShopperTrakApiClient:
             )
 
         # Determine if unhealthy data with 0 entrances/exits is missing or imputed by
-        # checking if it occurs during a library's regular hours. This assumes imputed
-        # data during a library's regular hours will always have at least one entrance/
-        # exit, but this is acceptable as it's preferable to erroneously mark imputed
-        # data as missing than the reverse.
+        # checking if it occurs during a library's regular hours. This 1) assumes that
+        # imputed data during a library's regular hours will always have at least one
+        # entrance/exit, and 2) ignores irregular closures. However, these are
+        # acceptable assumptions, as it's preferable to erroneously mark imputed
+        # data as missing than to do the reverse.
         if is_healthy_data or is_recovery_mode or enters > 0 or exits > 0:
             is_missing_data = False
         else:


### PR DESCRIPTION
This should stop certain false alarms from firing. In particular, the "nd" ShopperTrak site successfully sent unhealthy data through January when it was under renovation. Now the site has been temporarily turned off and the API for the site is no longer accessible even when querying for past data.

This will NOT stop an alarm from firing if a site sent unhealthy data when it was _open_ and then gets shut off. However, in this case, we likely want to keep retrying anyway, so there's no good way to prevent this.