### PR TITLE
Upgrade to ShopperTrak 2.0 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026-01-23 -- v1.2.0
+### Added
+- Use v2 of ShopperTrak API
+
 ## 2026-01-16 -- v1.1.5
 ### Added
 - Use v2 hours and closures tables

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LocationVisitsPoller
 
-The LocationVisitsPoller periodically hits the ShopperTrak API for the number of incoming and outgoing visitors per location per day and writes the data to LocationVisits Kinesis streams for ingest into the [BIC](https://github.com/NYPL/BIC). Note that because there are onerous ShopperTrak API rate limits and there is no QA version of the API, the poller is only deployed to production and there is no QA version.
+The LocationVisitsPoller periodically hits the [ShopperTrak API](https://drive.google.com/file/d/1VU38EvzZTp4wJYTIdA-zZuHgvfTN7Ei0/view?usp=sharing) for the number of incoming and outgoing visitors per location per day and writes the data to LocationVisits Kinesis streams for ingest into the [BIC](https://github.com/NYPL/BIC). Note that because there are onerous ShopperTrak API rate limits and there is no QA version of the API, the poller is only deployed to production and there is no QA version.
 
 ## Running locally
 * Add your `AWS_PROFILE` to the config file for the environment you want to run

--- a/config/devel.yaml
+++ b/config/devel.yaml
@@ -2,7 +2,7 @@
 PLAINTEXT_VARIABLES:
     AWS_REGION: us-east-1
     REDSHIFT_DB_NAME: dev
-    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v1.0/service/
+    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v2.0/service/
     LOCATION_VISITS_SCHEMA_URL: https://qa-platform.nypl.org/api/v0.1/current-schemas/LocationVisits
     ALL_SITES_S3_BUCKET: shoppertrak-sites
     ALL_SITES_S3_RESOURCE: site_ids.json

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -2,7 +2,7 @@
 PLAINTEXT_VARIABLES:
     AWS_REGION: us-east-1
     REDSHIFT_DB_NAME: production
-    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v1.0/service/
+    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v2.0/service/
     LOCATION_VISITS_SCHEMA_URL: https://platform.nypl.org/api/v0.1/current-schemas/LocationVisits
     S3_BUCKET: bic-poller-states-production
     S3_RESOURCE: location_visits_poller_state.json

--- a/lib/shoppertrak_api_client.py
+++ b/lib/shoppertrak_api_client.py
@@ -51,8 +51,18 @@ class ShopperTrakApiClient:
         try:
             response = requests.get(
                 full_url,
-                params={"date": date_str, "increment": "15", "total_property": "N"},
                 auth=self.auth,
+                headers={
+                    "Content-Type": "application/xml",
+                    "Cache-Control": "no-cache",
+                    "Pragma": "no-cache",
+                },
+                params={
+                    "date": date_str,
+                    "increment": "15",
+                    "total_property_only": "false",
+                    "detail": "entrance",
+                },
             )
             response.raise_for_status()
         except RequestException as e:
@@ -89,12 +99,12 @@ class ShopperTrakApiClient:
         <sites>
             <site siteID="lib a">
                 <date dateValue="20240101">
-                    <entrance name="EP 01">
+                    <entrance entranceName="EP 01">
                         <traffic code="01" exits="10" enters="11" startTime="000000"/>
                         <traffic code="02" exits="0" enters="0" startTime="001500"/>
                         ...
                     </entrance>
-                    <entrance name="EP2">
+                    <entrance entranceName="EP2">
                         <traffic .../>
                         ...
                     </entrance>
@@ -124,7 +134,7 @@ class ShopperTrakApiClient:
                     )
                 for entrance_xml in date_xml.findall("entrance"):
                     seen_timestamps = set()
-                    entrance_val = self._get_xml_str(entrance_xml, "name")
+                    entrance_val = self._get_xml_str(entrance_xml, "entranceName")
                     if entrance_val:
                         entrance_val = self._cast_str_to_int(entrance_val.lstrip("EP"))
                     for traffic_xml in entrance_xml.findall("traffic"):
@@ -232,10 +242,24 @@ class ShopperTrakApiClient:
             elif error.text == "E000" or error.text == "E108":
                 self.logger.info("ShopperTrak is unavailable")
                 return APIStatus.RETRY, None
+            elif error.text == "E104":
+                log_based_on_poll_date(
+                    self.logger,
+                    f"The site ID supplied has multiple matches: {response_text}",
+                    is_bad_poll_date,
+                )
+                return APIStatus.ERROR, None
+            elif error.text == "E110":
+                log_based_on_poll_date(
+                    self.logger,
+                    f"The current user does not have access to the given site: {response_text}",
+                    is_bad_poll_date,
+                )
+                return APIStatus.ERROR, None
             else:
                 log_based_on_poll_date(
                     self.logger,
-                    f"Error found in XML response: {response_text}",
+                    f"Error code {error.text} found in XML response: {response_text}",
                     is_bad_poll_date,
                 )
                 return APIStatus.ERROR, None

--- a/tests/test_shoppertrak_api_client.py
+++ b/tests/test_shoppertrak_api_client.py
@@ -14,13 +14,13 @@ _PRETTY_API_RESPONSE = """
 <sites>
 	<site siteID="aa">
 		<date dateValue="20231231">
-			<entrance name="EP 01">
+			<entrance entranceName="EP 01">
 				<traffic code="01" exits="0" enters="0" startTime="000000"/>
 				<traffic code="01" exits="1" enters="2" startTime="010000"/>
 				<traffic code="01" exits="3" enters="4" startTime="020000"/>
 				<traffic code="01" exits="0" enters="0" startTime="030000"/>
 			</entrance>
-			<entrance name=" EP02 ">
+			<entrance entranceName=" EP02 ">
 				<traffic code="01" exits="5" enters="6" startTime="000000"/>
 				<traffic code="01" exits="0" enters="0" startTime="010000"/>
 				<traffic code="02" exits="0" enters="0" startTime="020000"/>
@@ -30,7 +30,7 @@ _PRETTY_API_RESPONSE = """
 	</site>
     <site siteID="bb - test sublocation">
 		<date dateValue="20231231">
-			<entrance name="EP 1">
+			<entrance entranceName="EP 1">
 				<traffic code="02" exits="99" enters="99" startTime="000000"/>
 				<traffic code="02" exits="0" enters="0" startTime="010000"/>
 				<traffic code="02" exits="0" enters="0" startTime="020000"/>
@@ -106,7 +106,7 @@ class TestPipelineController:
     def test_query(self, test_instance, requests_mock, mocker):
         requests_mock.get(
             "https://test_shoppertrak_url/test%20-%20endpoint%3B%20one"
-            "?date=20231231&increment=15&total_property=N",
+            "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text=_TEST_API_RESPONSE,
         )
 
@@ -136,7 +136,7 @@ class TestPipelineController:
     def test_query_non_fatal_error(self, test_instance, requests_mock, mocker):
         requests_mock.get(
             "https://test_shoppertrak_url/test_endpoint"
-            "?date=20231231&increment=15&total_property=N",
+            "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="error",
         )
         mocker.patch("lib.ShopperTrakApiClient._check_response",
@@ -150,7 +150,7 @@ class TestPipelineController:
         mock_sleep = mocker.patch("time.sleep")
         requests_mock.get(
             "https://test_shoppertrak_url/test_endpoint"
-            "?date=20231231&increment=15&total_property=N",
+            "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             [{"text": "error"}, {"text": "error2"}, {"text": _TEST_API_RESPONSE}],
         )
 
@@ -174,7 +174,7 @@ class TestPipelineController:
         mock_sleep = mocker.patch("time.sleep")
         requests_mock.get(
             "https://test_shoppertrak_url/test_endpoint"
-            "?date=20231231&increment=15&total_property=N",
+            "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="error",
         )
         mocked_check_response_method = mocker.patch(
@@ -192,7 +192,7 @@ class TestPipelineController:
     def test_query_bad_status(self, test_instance, requests_mock, mocker, caplog):
         requests_mock.get(
             "https://test_shoppertrak_url/test_endpoint"
-            "?date=20231231&increment=15&total_property=N",
+            "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="",
         )
         mocker.patch("lib.ShopperTrakApiClient._check_response",
@@ -254,7 +254,7 @@ class TestPipelineController:
                 '<description>Error!</description></message>',
                 date(2023, 12, 31))
 
-        assert "Error found in XML response:" in caplog.text
+        assert "Error code E999 found in XML response:" in caplog.text
         assert status == APIStatus.ERROR
         assert root is None
 


### PR DESCRIPTION
As per [DE-573](https://newyorkpubliclibrary.atlassian.net/browse/DE-573). Not sure if/when this would be deployed given your ongoing v2 table updates, but thought this PR would be helpful in showing how minor the API updates would be! Here's a sample pipeline run (without ingestion):
<img width="998" height="537" alt="Screenshot 2026-01-22 at 11 46 17 AM" src="https://github.com/user-attachments/assets/9b8ea86b-3fa8-4828-9938-7992df1fe518" />

Not seeing any alerting but also not noticing any significant gains in retrieving unhealthy data...

[DE-573]: https://newyorkpubliclibrary.atlassian.net/browse/DE-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ