### PR TITLE
Funneling recovered API data to nypl-data-lake-test S3 bucket

### DIFF
--- a/config/devel.yaml
+++ b/config/devel.yaml
@@ -6,6 +6,8 @@ PLAINTEXT_VARIABLES:
     LOCATION_VISITS_SCHEMA_URL: https://qa-platform.nypl.org/api/v0.1/current-schemas/LocationVisits
     ALL_SITES_S3_BUCKET: shoppertrak-sites
     ALL_SITES_S3_RESOURCE: site_ids.json
+    DATA_LAKE_S3_BUCKET: nypl-data-lake-test
+    DATA_LAKE_S3_PATH: recovered_shoppertrak_visits_json/
     MAX_RETRIES: 3
     LOG_LEVEL: info
     LAST_POLL_DATE: 2024-03-25

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -2,12 +2,14 @@
 PLAINTEXT_VARIABLES:
     AWS_REGION: us-east-1
     REDSHIFT_DB_NAME: production
-    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v2.0/service/
+    SHOPPERTRAK_API_BASE_URL: https://stws.shoppertrak.com/Traffic/Customer/v2.0/
     LOCATION_VISITS_SCHEMA_URL: https://platform.nypl.org/api/v0.1/current-schemas/LocationVisits
     S3_BUCKET: bic-poller-states-production
     S3_RESOURCE: location_visits_poller_state.json
     ALL_SITES_S3_BUCKET: shoppertrak-sites
     ALL_SITES_S3_RESOURCE: site_ids.json
+    DATA_LAKE_S3_BUCKET: nypl-data-lake-test
+    DATA_LAKE_S3_PATH: recovered_shoppertrak_visits_json/
     KINESIS_BATCH_SIZE: 500
     MAX_RETRIES: 3
     BAD_POLL_DATES:

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -276,7 +276,7 @@ class PipelineController:
                 s3_path = (
                     os.environ["DATA_LAKE_S3_PATH"]
                     + visits_date.strftime("%Y/%m/%d/")
-                    + f"{site_id}.json"
+                    + f"{int(datetime.now(pytz.utc).timestamp())}.json"
                 )
                 self.data_lake_s3_client.put_object(
                     Key=s3_path, Body=site_response_json.encode("utf-8")

--- a/lib/pipeline_controller.py
+++ b/lib/pipeline_controller.py
@@ -1,3 +1,4 @@
+import boto3
 import itertools
 import json
 import os
@@ -69,6 +70,11 @@ class PipelineController:
         )
         self.all_site_ids = set(all_sites_s3_client.fetch_cache())
         all_sites_s3_client.close()
+
+        # Temp addition while testing out Snowflake data lake
+        self.data_lake_s3_client = boto3.resource("s3").Bucket(
+            os.environ["DATA_LAKE_S3_BUCKET"]
+        )
 
         self.ignore_update = os.environ.get("IGNORE_UPDATE", False) == "True"
         self.ignore_cache = os.environ.get("IGNORE_CACHE", False) == "True"
@@ -209,6 +215,7 @@ class PipelineController:
             missing_site_dates = sorted(missing_site_dates, key=lambda x: (x[1], x[0]))
             self.logger.info("Re-querying for previously missing data")
             self._recover_data(missing_site_dates, dict(), is_recovery_mode=False)
+            self._recover_and_send_json_data_to_s3(missing_site_dates)
 
         # For all the site/date pairs with unhealthy data, form a dictionary of the
         # currently stored data for those sites on those dates where the key is (site
@@ -231,6 +238,7 @@ class PipelineController:
             }
         self.logger.info("Re-querying for previously unhealthy data")
         self._recover_data(unhealthy_site_dates, known_data_dict)
+        self._recover_and_send_json_data_to_s3(unhealthy_site_dates)
         self.redshift_client.close_connection()
 
     def _recover_data(self, site_dates, known_data_dict, is_recovery_mode=True):
@@ -253,6 +261,26 @@ class PipelineController:
                     site_response, visits_date, is_recovery_mode=is_recovery_mode
                 )
                 self._process_recovered_data(site_results, known_data_dict)
+
+    def _recover_and_send_json_data_to_s3(self, site_dates):
+        """
+        Temporary function. Individually query the ShopperTrak API for each site/date
+        pair with any unhealthy data, then save the JSON response to S3 for later
+        use in the data lake.
+        """
+        for site_id, visits_date in site_dates:
+            site_response_json = self.shoppertrak_api_client.json_query(
+                SINGLE_SITE_ENDPOINT + site_id, visits_date
+            )
+            if site_response_json is not None:
+                s3_path = (
+                    os.environ["DATA_LAKE_S3_PATH"]
+                    + visits_date.strftime("%Y/%m/%d/")
+                    + f"{site_id}.json"
+                )
+                self.data_lake_s3_client.put_object(
+                    Key=s3_path, Body=site_response_json.encode("utf-8")
+                )
 
     def _process_recovered_data(self, recovered_data, known_data_dict):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,8 @@ TEST_ENV_VARS = {
     "KINESIS_STREAM_ARN": "test_kinesis_stream",
     "SHOPPERTRAK_USERNAME": "test_shoppertrak_username",
     "SHOPPERTRAK_PASSWORD": "test_shoppertrak_password",
+    "DATA_LAKE_S3_BUCKET": "test_data_lake_bucket",
+    "DATA_LAKE_S3_PATH": "test_data_lake_resource",
 }
 
 

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -274,6 +274,9 @@ class TestPipelineController:
         mocked_recover_data_method = mocker.patch(
             "lib.pipeline_controller.PipelineController._recover_data"
         )
+        mocker.patch(
+            "lib.pipeline_controller.PipelineController._recover_and_send_json_data_to_s3"
+        )
         test_instance.redshift_client.execute_query.side_effect = [
             [],
             (
@@ -332,6 +335,9 @@ class TestPipelineController:
     ):
         mocked_recover_data_method = mocker.patch(
             "lib.pipeline_controller.PipelineController._recover_data"
+        )
+        mocker.patch(
+            "lib.pipeline_controller.PipelineController._recover_and_send_json_data_to_s3"
         )
         test_instance.redshift_client.execute_query.side_effect = [
             (

--- a/tests/test_shoppertrak_api_client.py
+++ b/tests/test_shoppertrak_api_client.py
@@ -105,7 +105,7 @@ class TestPipelineController:
 
     def test_query(self, test_instance, requests_mock, mocker):
         requests_mock.get(
-            "https://test_shoppertrak_url/test%20-%20endpoint%3B%20one"
+            "https://test_shoppertrak_url/service/test%20-%20endpoint%3B%20one"
             "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text=_TEST_API_RESPONSE,
         )
@@ -121,7 +121,7 @@ class TestPipelineController:
 
     def test_query_request_exception(self, test_instance, requests_mock, mocker, caplog):
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint", exc=ConnectTimeout
+            "https://test_shoppertrak_url/service/test_endpoint", exc=ConnectTimeout
         )
         mocked_check_response_method = mocker.patch(
             "lib.ShopperTrakApiClient._check_response")
@@ -130,12 +130,12 @@ class TestPipelineController:
             test_instance.query("test_endpoint", date(2023, 12, 31))
         
         assert ("Failed to retrieve response from "
-                "https://test_shoppertrak_url/test_endpoint") in caplog.text
+                "https://test_shoppertrak_url/service/test_endpoint") in caplog.text
         mocked_check_response_method.assert_not_called()
     
     def test_query_non_fatal_error(self, test_instance, requests_mock, mocker):
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint"
+            "https://test_shoppertrak_url/service/test_endpoint"
             "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="error",
         )
@@ -149,7 +149,7 @@ class TestPipelineController:
         test_date = date(2023, 12, 31)
         mock_sleep = mocker.patch("time.sleep")
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint"
+            "https://test_shoppertrak_url/service/test_endpoint"
             "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             [{"text": "error"}, {"text": "error2"}, {"text": _TEST_API_RESPONSE}],
         )
@@ -173,7 +173,7 @@ class TestPipelineController:
     def test_query_retry_fail(self, test_instance, requests_mock, mocker, caplog):
         mock_sleep = mocker.patch("time.sleep")
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint"
+            "https://test_shoppertrak_url/service/test_endpoint"
             "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="error",
         )
@@ -191,7 +191,7 @@ class TestPipelineController:
 
     def test_query_bad_status(self, test_instance, requests_mock, mocker, caplog):
         requests_mock.get(
-            "https://test_shoppertrak_url/test_endpoint"
+            "https://test_shoppertrak_url/service/test_endpoint"
             "?date=20231231&increment=15&total_property_only=false&detail=entrance",
             text="",
         )


### PR DESCRIPTION
As per [DE-557](https://newyorkpubliclibrary.atlassian.net/browse/DE-541). Function naming may be a bit wonky so feel free to suggest alternatives! [Here's the bucket with data recovered today](https://us-east-1.console.aws.amazon.com/s3/buckets/nypl-data-lake-test?region=us-east-1&prefix=recovered_shoppertrak_visits_json/&showversions=false).

[DE-557]: https://newyorkpubliclibrary.atlassian.net/browse/DE-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ